### PR TITLE
loaded the window size and added to specs for path builder

### DIFF
--- a/index.js
+++ b/index.js
@@ -246,9 +246,12 @@ function Jasmine2ScreenShotReporter(opts) {
           var afterSpec = function(done) {
               browser.getCapabilities().then(function (capabilities) {
                   clonedSpec._capabilities = capabilities;
-                  browser.takeScreenshot().then(function (png) {
-                      clonedSpec._png = png;
-                      done();
+                  browser.driver.manage().window().getSize().then(function(windowSize) {
+                      clonedSpec._windowSize = windowSize;
+                      browser.takeScreenshot().then(function (png) {
+                          clonedSpec._png = png;
+                          done();
+                      });
                   });
               });
           }
@@ -278,7 +281,7 @@ function Jasmine2ScreenShotReporter(opts) {
           return;
         }
 
-        file = opts.pathBuilder(spec, suites, spec._capabilities);
+        file = opts.pathBuilder(spec, suites, spec._capabilities, spec._windowSize);
         spec.filename = file + '.png';
 
         var screenshotPath,


### PR DESCRIPTION
if you're running tests with multiple resolutions using multiCapabilities, the options available in the path builder are not able to distinguish between different instances of the same browser (with different resolutions), therefore overwriting the screenshots (or having to use some random id).

with this addition, screenshots can be saved as eg 'chrome-1920-1200/test.png':

    pathBuilder: function(currentSpec, suites, browserCapabilities, windowSize) {
        // will return chrome-1920/your-spec-name.png
        return browserCapabilities.get('browserName') + '-' + windowSize.width + '/' + currentSpec.fullName;
    }